### PR TITLE
Document edge cases having to do with empty or non-existing values

### DIFF
--- a/docs/Reference/jatos.js-Reference.md
+++ b/docs/Reference/jatos.js-Reference.md
@@ -1297,7 +1297,7 @@ JSON Patch test operation: Tests that the specified value is set in the document
 
 ### `jatos.batchSession.add`
 
-JSON Patch add operation: Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The `-` character can be used instead of an index to insert at the end of an array (see [jsonpatch.com](http://jsonpatch.com/)). If the path already exists in the Batch Session the value will be overwritten. The patch will fail if a key other than the innermost one does not already exist.
+JSON Patch add operation: Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The `-` character can be used instead of an index to insert at the end of an array (see [jsonpatch.com](http://jsonpatch.com/)). If the path already exists in the Batch Session the value will be overwritten. The patch will fail if a key other than the last path element is missing, e.g., when the path is `"/a/b/c"`, if `"a"` and `"b"` do not already exist as keys, the patch will fail.
 
 * _@param {string} path_ - JSON pointer path
 * _@param {object} value_ - value to be stored
@@ -1993,7 +1993,7 @@ the first line returns true, second false and third true.
 
 ### `jatos.groupSession.add`
 
-JSON Patch add operation: Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The `-` character can be used instead of an index to insert at the end of an array (see [jsonpatch.com](http://jsonpatch.com/)). If the path already exists in the Group Session the value will be overwritten. The patch will fail if a key other than the innermost one does not already exist.
+JSON Patch add operation: Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The `-` character can be used instead of an index to insert at the end of an array (see [jsonpatch.com](http://jsonpatch.com/)). If the path already exists in the Group Session the value will be overwritten. The patch will fail if a key other than the last path element is missing, e.g., when the path is `"/a/b/c"`, if `"a"` and `"b"` do not already exist as keys, the patch will fail.
 
 * _@param {string} path_ - JSON pointer path
 * _@param {object} value_ - value to be stored

--- a/docs/Reference/jatos.js-Reference.md
+++ b/docs/Reference/jatos.js-Reference.md
@@ -13,7 +13,7 @@ Always load _jatos.js_ in the `<head>` section with the following line:
 <script src="jatos.js"></script>
 ```
 
-All _jatos.js_ variables or functions start with `jatos.`. For example, if you want to get the study's ID you use `jatos.studyId`. 
+All _jatos.js_ variables or functions start with `jatos.`. For example, if you want to get the study's ID you use `jatos.studyId`.
 
 Most _jatos.js_ variables or functions only work after _jatos.js_ is initialized (`jatos.onLoad()` is used).
 
@@ -148,7 +148,7 @@ Time in ms to wait for an answer after sending a message via a channel (batch or
 ```javascript
 jatos.channelSendingTimeoutTime = 20000; // Sets channel timeout to 20 seconds
 ```
-  
+
 ### `jatos.channelHeartbeatInterval`
 
 Waiting time in ms between channel (group or batch) heartbeats (default is 25 s)
@@ -158,7 +158,7 @@ Waiting time in ms between channel (group or batch) heartbeats (default is 25 s)
 ```javascript
 jatos.channelHeartbeatInterval = 10000; // Sets interval to 10 seconds
 ```
-  
+
 ### `jatos.channelHeartbeatTimeoutTime`
 
 Waiting time in ms for JATOS server's answer to a channel heartbeat (default is 10 s)
@@ -168,7 +168,7 @@ Waiting time in ms for JATOS server's answer to a channel heartbeat (default is 
 ```javascript
 jatos.channelHeartbeatTimeoutTime = 20000; // Sets interval to 20 seconds
 ```
-  
+
 ### `jatos.channelClosedCheckInterval`
 
 Waiting time in ms between checking if channels (group or batch) are closed unexpectedly (default is 2 s)
@@ -178,8 +178,8 @@ Waiting time in ms between checking if channels (group or batch) are closed unex
 ```javascript
 jatos.channelClosedCheckInterval = 4000; // Sets interval to 4 seconds
 ```
-  
-### `jatos.channelOpeningBackoffTimeMin` 
+
+### `jatos.channelOpeningBackoffTimeMin`
 
 Min waiting time (in ms) between channel reopening attempts (default is 1s for min and 2 min for max). _jatos.js_ uses an _exponential back-off_ retry pattern for the channels.
 
@@ -208,17 +208,17 @@ Time in ms to wait for an answer of an HTTP request by _jatos.js_. Set this vari
 ```javascript
 jatos.httpTimeout = 30000; // Sets HTTP timeout to 30 seconds
 ```
-  
+
 ### `jatos.httpRetry`
 
-Some jatos functions (e.g. `jatos.sendResultData`) send an Ajax request to the JATOS server. If this request was not successful (e.g. network problems) _jatos.js_ retries it. With this variable one can change the number of retries. The default is 5. 
+Some jatos functions (e.g. `jatos.sendResultData`) send an Ajax request to the JATOS server. If this request was not successful (e.g. network problems) _jatos.js_ retries it. With this variable one can change the number of retries. The default is 5.
 
 **Example**
 
 ```javascript
 jatos.httpRetry = 2; // Attempts 2 retries of failed Ajax requests
 ```
-  
+
 ### `jatos.httpRetryWait`
 
 Same as `jatos.httpRetry` but this variable defines the waiting time between the retries. The default is 1000 ms.
@@ -358,12 +358,12 @@ Convenience function that shows a text and an image in the center of the screen.
      imgUrl: "http://url-to-my-coffee-picture",
      style: "color:brown"
    });
-   ```   
+   ```
 
-### `jatos.removeOverlay` 
+### `jatos.removeOverlay`
 
 Removes an overlay that was added by jatos.showOverlay.
- 
+
 **Example**
 
 ```javascript
@@ -371,11 +371,11 @@ jatos.removeOverlay()
 ```
 
 
-### `jatos.onError` 
+### `jatos.onError`
 
 DEPRECATED - use the specific function's error callback or Promise function instead
 
-Defines a callback function that is to be called in case _jatos.js_ produces an error. 
+Defines a callback function that is to be called in case _jatos.js_ produces an error.
 
 * _@param {function} callback_ - Function to be called in case of an error
 
@@ -392,7 +392,7 @@ jatos.onError(alert);
 
 Sends a message to be logged back to the JATOS server where it will be logged in JATOS' log file.
 
-* _@param {string} logMsg_ - The messages to be logged  
+* _@param {string} logMsg_ - The messages to be logged
 
 **Example**
 
@@ -403,8 +403,8 @@ jatos.log("Log this message in JATOS' log file");
 
 ### `jatos.catchAndLogErrors`
 
-Convenience function that sends all 'error' and 'unhandledrejection' events and 'console.error' and 'console.warn' calls to [JATOS' server log](Troubleshooting.html#read-log-file-in-the-browser). This is useful in debugging. 
-	 
+Convenience function that sends all 'error' and 'unhandledrejection' events and 'console.error' and 'console.warn' calls to [JATOS' server log](Troubleshooting.html#read-log-file-in-the-browser). This is useful in debugging.
+
 **Example**
 
 ```javascript
@@ -468,12 +468,12 @@ There are two versions: with or without message
 
 1. Without message:
 	* _@param {number} componentIdOrUuid_ - ID or UUID of the component to start
-   * _@param {optional object} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify). 
+   * _@param {optional object} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify).
    * _@param {optional function} onError_ - Callback function if fail
 
 1. With message:
 	 * _@param {number} componentIdOrUuid_ - ID or UUID of the component to start
-	 * _@param {optional object} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify). 
+	 * _@param {optional object} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify).
 	 * _@param {optional string} message_ - Message that should be logged (max 255 chars)
 	 * _@param {optional function} onError_ - Callback function if fail
 
@@ -498,7 +498,7 @@ There are two versions: with or without message
    jatos.startComponent(23, resultData);
    ```
 
-1. Send result data, jump to another component and send a message back that will be visible in JATOS result pages and log 
+1. Send result data, jump to another component and send a message back that will be visible in JATOS result pages and log
 
    ```javascript
    var resultData = "my important result data";
@@ -515,13 +515,13 @@ There are two versions: with or without message
 1. Without message
 
    * _@param {number} componentPos_ - Position of the component to start
-   * _@param {optional object} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify). 
+   * _@param {optional object} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify).
    * _@param {optional function} onError_ - Callback function if fail
 
 1. With message
 
    * _@param {number} componentPos_ - Position of the component to start
-	 * _@param {optional object or string} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify). 
+	 * _@param {optional object or string} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify).
 	 * _@param {optional string} message_ - Message that should be logged (max 255 chars)
 	 * _@param {optional function} onError_ - Callback function if fail
 
@@ -540,7 +540,7 @@ There are two versions: with or without message
    jatos.startComponentByPos(3, resultData);
    ```
 
-1. Send result data, jump to component in position 3 and send a message back that will be visible in JATOS result pages and log 
+1. Send result data, jump to component in position 3 and send a message back that will be visible in JATOS result pages and log
 
    ```javascript
    var resultData = "my important result data";
@@ -556,12 +556,12 @@ There are two versions: with or without message
 
 1. Without message
 
-   * _@param {optional object} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify). 
+   * _@param {optional object} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify).
    * _@param {optional function} onError_ - Callback function if fail
 
 1. With message
 
-	 * _@param {optional object or string} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify). 
+	 * _@param {optional object or string} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify).
 	 * _@param {optional string} message_ - Message that should be logged (max 255 chars)
 	 * _@param {optional function} onError_ - Callback function if fail
 
@@ -580,7 +580,7 @@ There are two versions: with or without message
    jatos.startNextComponent(resultData);
    ```
 
-1. Send result data, jump to the next component and send a message back that will be visible in JATOS result pages and log 
+1. Send result data, jump to the next component and send a message back that will be visible in JATOS result pages and log
 
    ```javascript
    var resultData = "my important result data";
@@ -596,12 +596,12 @@ There are two versions: with or without message
 
 1. Without message
 
-	 * _@param {optional object} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify). 
+	 * _@param {optional object} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify).
    * _@param {optional function} onError_ - Callback function if fail
 
 1. With message
 
-	 * _@param {optional object or string} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify). 
+	 * _@param {optional object or string} resultData_ - String or object that will be sent as result data. An object will be serialized to JSON (stringify).
 	 * _@param {optional string} message_ - Message that should be logged (max 255 chars)
 	 * _@param {optional function} onError_ - Callback function if fail
 
@@ -703,7 +703,7 @@ There are two versions: with and without result data
    jatos.endStudy();
    ```
 
-1. End study and send a message back that will be visible in JATOS result pages and log 
+1. End study and send a message back that will be visible in JATOS result pages and log
 
    ```javascript
    jatos.endStudy(true, "everything worked fine");
@@ -756,7 +756,7 @@ Ends study and redirects the given URL. This is useful if you want to let the wo
    ```javascript
    var resultData = {id: 123, data: "my important result data"};
    jatos.endStudyAndRedirect("https://app.prolific.co/submissions/complete?cc=1234ABCD", resultData);
-   ```    
+   ```
 
 1. End study and redirect afterwards. A message will be sent back to JATOS and shown in the result page and put in the log.
 
@@ -800,14 +800,14 @@ Ends study with an Ajax call - afterwards the study is not redirected to the JAT
    ```javascript
    jatos.endStudyAjax(false, "some error description");
    ```
-   
+
 1. End study and show the confirmation code to the MTurk worker
 
    ```javascript
    jatos.endStudyAjax().then((confirmationCode) => {
      // Show the confirmation code to the worker
    });
-   ```   
+   ```
 
 1. Use Promise to submit result data and afterwards, end the study and move to another URL ([see also](jatos.js-Reference.html#jatosendstudyandredirect))
 
@@ -817,7 +817,7 @@ Ends study with an Ajax call - afterwards the study is not redirected to the JAT
      .then(jatos.endStudyAjax)
      .then(() => { window.location.href = 'http://example.com/index.html' })
      .catch(() => console.log("Something went wrong"));
-   ``` 
+   ```
 
 1. Send result data and end study
 
@@ -1056,9 +1056,9 @@ The Batch Session is stored in JATOS' database on the server side (see also [Ses
 
 On the other side for all reading functions (`get`, `find`, `getAll`, `test`) there is no need to sync data between client and server, because _jatos.js_ keeps a copy of the Batch Session locally. Therefore all reading functions do not offer callbacks, because there is no risk of failure of synchronization.
 
-Additionally to the reading and writing functions the calback function `jatos.onBatchSession(callback)` offers a way to get notified whenever the Batch Session changes in the JATOS' database regardless of the origin of the change. This way, you can have the client of each worker react to changes in the batch that were done by another worker in the batch. 
+Additionally to the reading and writing functions the calback function `jatos.onBatchSession(callback)` offers a way to get notified whenever the Batch Session changes in the JATOS' database regardless of the origin of the change. This way, you can have the client of each worker react to changes in the batch that were done by another worker in the batch.
 
-Accessing the Batch Session is done via [JSON Patches (RFC 6902)](https://tools.ietf.org/html/rfc6902) and 
+Accessing the Batch Session is done via [JSON Patches (RFC 6902)](https://tools.ietf.org/html/rfc6902) and
 [JSON Pointer (RFC 6901)](https://tools.ietf.org/html/rfc6901). An introduction can be found under [jsonpatch.com](http://jsonpatch.com/). For JSON Patches _jatos.js_ uses the [JSON-Patch](https://github.com/Starcounter-Jack/JSON-Patch) library from Joachim Wester and for JSON Pointers the [jsonpointer.js](https://github.com/alexeykuzmin/jsonpointer.js) library from Alexey Kuzmin.
 
 
@@ -1094,7 +1094,7 @@ The callback function has two parameter:
 
 Convenience function: like `jatos.batchSession.find` but works with a key instead of a JSON Pointer. Therefore it works only on the first level of the session's object tree. It takes a name of an field within the Batch Session and returns the matching value.  For all other levels of the object tree use jatos.batchSession.find. Gets the object from the locally stored copy of the session and does not call the server.
 
-* _@param {string} name_ - name of the field 
+* _@param {string} name_ - name of the field
 * _@return {object}_ - the value that is stored under name
 
 **Examples**
@@ -1121,7 +1121,7 @@ Convenience function: like `jatos.batchSession.find` but works with a key instea
 
 A convenience function for `jatos.batchSession.add`. Instead of a JSON Pointer path it accepts a name of the field to be stored (without a slash in front). Therefore it works only on the first level of the Batch Session's object tree. If the name already exists in the Batch Session the value will be overwritten.
 
-* _@param {string} name_ - name of the field 
+* _@param {string} name_ - name of the field
 * _@param {object} value_ - value to be stored
 * _@param {optional callback} onSuccess_ - Function to be called if this patch was successfully applied on the server and the client side
 * _@param {optional callback} onError_ - Function to be called if this patch failed
@@ -1234,7 +1234,7 @@ Clears the whole Batch Session data and sets it to an empty object `{}`.
 
 Gets a field in the Batch Session data. Takes a JSON Pointer and returns the matching value. Gets the object from the locally stored copy of the session and does not call the server. Contrary to `jatos.batchSession.get` it allows to get values from all levels of the Batch Session's object tree.
 
-* _@param {string} path_ - JSON pointer path 
+* _@param {string} path_ - JSON pointer path
 * _@return {object}_ - the value that is stored in path
 
 **Example**
@@ -1298,7 +1298,7 @@ JSON Patch test operation: Tests that the specified value is set in the document
 
 JSON Patch add operation: Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The `-` character can be used instead of an index to insert at the end of an array (see [jsonpatch.com](http://jsonpatch.com/)). If the path already exists in the Batch Session the value will be overwritten.
 
-* _@param {string} path_ - JSON pointer path 
+* _@param {string} path_ - JSON pointer path
 * _@param {object} value_ - value to be stored
 * _@param {optional callback} onSuccess_ - Function to be called if this patch was successfully applied on the server and the client side
 * _@param {optional callback} onError_ - Function to be called if this patch failed
@@ -1333,7 +1333,7 @@ JSON Patch add operation: Adds a value to an object or inserts it into an array.
       .then(() => console.log("Batch Session was successfully updated"))
       .catch(() => console.log("Batch Session synchronization failed"));
    ```
-   
+
 1. Add an object:
 
    ```javascript
@@ -1341,9 +1341,9 @@ JSON Patch add operation: Adds a value to an object or inserts it into an array.
       .then(() => console.log("Batch Session was successfully updated"))
       .catch(() => console.log("Batch Session synchronization failed"));
    ```
-   
+
    Afterwards the Batch Session contains `{"obj": {"foo": "bar"}}`.
-   
+
 1. Add an array:
 
    ```javascript
@@ -1362,7 +1362,7 @@ JSON Patch add operation: Adds a value to an object or inserts it into an array.
       .then(() => console.log("Batch Session was successfully updated"))
       .catch(() => console.log("Batch Session synchronization failed"));
    ```
-   
+
    then afterwards the Batch Session contains `{"array": [1, 2, "new", 3]}`.
 
 1. Append to the end of an array using `/-`:
@@ -1374,7 +1374,7 @@ JSON Patch add operation: Adds a value to an object or inserts it into an array.
       .then(() => console.log("Batch Session was successfully updated"))
       .catch(() => console.log("Batch Session synchronization failed"));
    ```
-   
+
    then afterwards the Batch Session contains `{"array": [1, 2, 3, "new"]}`.
 
 1. Have a series of Batch Session updates
@@ -1423,7 +1423,7 @@ JSON Patch remove operation: Removes a value from an object or array (see [jsonp
 
 JSON Patch replace operation: Replaces a value. Equivalent to a 'remove' followed by an 'add' (see [jsonpatch.com](http://jsonpatch.com/)).
 
-* _@param {string} path_ - JSON pointer path 
+* _@param {string} path_ - JSON pointer path
 * _@param {object} value_ - value to be replaced with
 * _@param {optional callback} onSuccess_ - Function to be called if this patch was successfully applied on the server and the client side
 * _@param {optional callback} onError_ - Function to be called if this patch failed
@@ -1456,7 +1456,7 @@ JSON Patch replace operation: Replaces a value. Equivalent to a 'remove' followe
 
 JSON Patch copy operation: Copies a value from one location to another within the JSON document. Both from and path are JSON Pointers (see [jsonpatch.com](http://jsonpatch.com/)).
 
-* _@param {string} from_ - JSON pointer path to the origin 
+* _@param {string} from_ - JSON pointer path to the origin
 * _@param {string} path_ - JSON pointer path to the target
 * _@param {optional callback} onSuccess_ - Function to be called if this patch was successfully applied on the server and the client side
 * _@param {optional callback} onError_ - Function to be called if this patch failed
@@ -1489,7 +1489,7 @@ JSON Patch copy operation: Copies a value from one location to another within th
 
 JSON Patch move operation: Moves a value from one location to the other. Both from and path are JSON Pointers. (see [jsonpatch.com](http://jsonpatch.com/)).
 
-* _@param {string} from_ - JSON pointer path to the origin 
+* _@param {string} from_ - JSON pointer path to the origin
 * _@param {string} path_ - JSON pointer path to the target
 * _@param {optional callback} onSuccess_ - Function to be called if this patch was successfully applied on the server and the client side
 * _@param {optional callback} onError_ - Function to be called if this patch failed
@@ -1787,7 +1787,7 @@ The Group Session is stored in JATOS' database on the server side. That means th
 
 On the other side for all reading functions (`get`, `find`, `getAll`, `test`) there is no need to sync data between client and server, because _jatos.js_ keeps a copy of the Group Session locally. Therefore all reading functions do not offer callbacks, because there is no risk of failure of synchronization.
 
-Accessing the Group Session is done via [JSON Patches (RFC 6902)](https://tools.ietf.org/html/rfc6902) and 
+Accessing the Group Session is done via [JSON Patches (RFC 6902)](https://tools.ietf.org/html/rfc6902) and
 [JSON Pointer (RFC 6901)](https://tools.ietf.org/html/rfc6901). An introduction can be found under [jsonpatch.com](http://jsonpatch.com/). For JSON Patches _jatos.js_ uses the [JSON-Patch](https://github.com/Starcounter-Jack/JSON-Patch) library from Joachim Wester and for JSON Pointers the [jsonpointer.js](https://github.com/alexeykuzmin/jsonpointer.js) library from Alexey Kuzmin.
 
 
@@ -1795,7 +1795,7 @@ Accessing the Group Session is done via [JSON Patches (RFC 6902)](https://tools.
 
 Convenience function: like `jatos.groupSession.find` but works with a key instead of a JSON Pointer (without the slash in front of the key name). Therefore it works only on the first level of the session's object tree. It takes a name of an field within the Group Session and returns the matching value.  For all other levels of the object tree use jatos.groupSession.find. Gets the object from the locally stored copy of the session and does not call the server.
 
-* _@param {string} name_ - name of the field 
+* _@param {string} name_ - name of the field
 * _@return {object}_ - the value that is stored under name
 
 **Examples**
@@ -1826,7 +1826,7 @@ Convenience function: like `jatos.groupSession.find` but works with a key instea
 
 A convenience function for `jatos.groupSession.add`. Instead of a JSON Pointer path it accepts a name of the field to be stored (without the slash in front). Therefore it works only on the first level of the Group Session's object tree. If the name already exists in the Group Session the value will be overwritten.
 
-* _@param {string} name_ - name of the field 
+* _@param {string} name_ - name of the field
 * _@param {object} value_ - value to be stored
 * _@param {optional callback} onSuccess_ - Function to be called if this patch was successfully applied on the server and the client side
 * _@param {optional callback} onError_ - Function to be called if this patch failed
@@ -1938,7 +1938,7 @@ Clears the whole Group Session data and sets it to an empty object `{}`.
 
 Gets a field in the Group Session data. Takes a JSON Pointer and returns the matching value. Gets the object from the locally stored copy of the session and does not call the server. Contrary to `jatos.groupSession.get` it allows to get values from all levels of the Group Session's object tree.
 
-* _@param {string} path_ - JSON pointer path 
+* _@param {string} path_ - JSON pointer path
 * _@return {object}_ - the value that is stored in path
 
 **Example**
@@ -1992,7 +1992,7 @@ the first line returns true, second false and third true.
 
 JSON Patch add operation: Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The `-` character can be used instead of an index to insert at the end of an array (see [jsonpatch.com](http://jsonpatch.com/)). If the path already exists in the Group Session the value will be overwritten.
 
-* _@param {string} path_ - JSON pointer path 
+* _@param {string} path_ - JSON pointer path
 * _@param {object} value_ - value to be stored
 * _@param {optional callback} onSuccess_ - Function to be called if this patch was successfully applied on the server and the client side
 * _@param {optional callback} onError_ - Function to be called if this patch failed
@@ -2000,7 +2000,7 @@ JSON Patch add operation: Adds a value to an object or inserts it into an array.
 
 **Examples**
 
-1. Add an a field to the Group Session 
+1. Add an a field to the Group Session
 
    If the Group Session is `{"a": 100}` and one calls
 
@@ -2081,7 +2081,7 @@ JSON Patch remove operation: Removes a value from an object or array (see [jsonp
 
 JSON Patch replace operation: Replaces a value. Equivalent to a “remove” followed by an “add” (see [jsonpatch.com](http://jsonpatch.com/)).
 
-* _@param {string} path_ - JSON pointer path 
+* _@param {string} path_ - JSON pointer path
 * _@param {object} value_ - value to be replaced with
 * _@param {optional callback} onSuccess_ - Function to be called if this patch was successfully applied on the server and the client side
 * _@param {optional callback} onError_ - Function to be called if this patch failed
@@ -2114,7 +2114,7 @@ JSON Patch replace operation: Replaces a value. Equivalent to a “remove” fol
 
 JSON Patch copy operation: Copies a value from one location to another within the JSON document. Both from and path are JSON Pointers (see [jsonpatch.com](http://jsonpatch.com/)).
 
-* _@param {string} from_ - JSON pointer path to the origin 
+* _@param {string} from_ - JSON pointer path to the origin
 * _@param {string} path_ - JSON pointer path to the target
 * _@param {optional callback} onSuccess_ - Function to be called if this patch was successfully applied on the server and the client side
 * _@param {optional callback} onError_ - Function to be called if this patch failed
@@ -2147,7 +2147,7 @@ JSON Patch copy operation: Copies a value from one location to another within th
 
 JSON Patch move operation: Moves a value from one location to the other. Both from and path are JSON Pointers. (see [jsonpatch.com](http://jsonpatch.com/)).
 
-* _@param {string} from_ - JSON pointer path to the origin 
+* _@param {string} from_ - JSON pointer path to the origin
 * _@param {string} path_ - JSON pointer path to the target
 * _@param {optional callback} onSuccess_ - Function to be called if this patch was successfully applied on the server and the client side
 * _@param {optional callback} onError_ - Function to be called if this patch failed

--- a/docs/Reference/jatos.js-Reference.md
+++ b/docs/Reference/jatos.js-Reference.md
@@ -79,7 +79,7 @@ All the properties (except the JSON input data) you entered for this study
 
 ### `jatos.studyJsonInput`
 
-The JSON input you entered in the study's properties.
+The JSON input you entered in the study's properties. This is `{}` if the field was left empty.
 
 ### `jatos.studyLength`
 
@@ -99,7 +99,7 @@ All the properties (except the JSON input data) you entered for this component
 
 ### `jatos.componentJsonInput`
 
-The JSON input you entered in the component's properties.
+The JSON input you entered in the component's properties. This is `{}` if the field was left empty.
 
 ### `jatos.componentList`
 
@@ -118,7 +118,7 @@ Current version of the _jatos.js_ library
 
 ### `jatos.urlQueryParameters`
 
-Original query string parameters of the URL that starts the study. It is provided as a JavaScript object. This might be useful to pass on information from outside of JATOS into a study run, e.g. if you want to pass on information like gender and age. However if you know the information beforehand it's easier to put them in the Study's or Component's JSON input. Another example is MTurk which passes on it's worker's ID via a URL query parameter.
+Original query string parameters of the URL that starts the study. It is provided as a JavaScript object; the value is `{}` if no query string parameters are present. This might be useful to pass on information from outside of JATOS into a study run, e.g. if you want to pass on information like gender and age. However if you know the information beforehand it's easier to put them in the Study's or Component's JSON input. Another example is MTurk which passes on it's worker's ID via a URL query parameter.
 
 **Examples**
 
@@ -1046,7 +1046,7 @@ All the properties you entered for this batch.
 
 ### `jatos.batchJsonInput`
 
-The JSON input you entered in the batch's properties.
+The JSON input you entered in the batch's properties. This is `{}` if the field was left empty.
 
 
 
@@ -1092,7 +1092,7 @@ The callback function has two parameter:
 
 ### `jatos.batchSession.get`
 
-Convenience function: like `jatos.batchSession.find` but works with a key instead of a JSON Pointer. Therefore it works only on the first level of the session's object tree. It takes a name of an field within the Batch Session and returns the matching value.  For all other levels of the object tree use jatos.batchSession.find. Gets the object from the locally stored copy of the session and does not call the server.
+Convenience function: like `jatos.batchSession.find` but works with a key instead of a JSON Pointer. Therefore it works only on the first level of the session's object tree. It takes a name of a field within the Batch Session and returns the matching value, or `undefined` if the key does not exist. For all other levels of the object tree use `jatos.batchSession.find`. Gets the object from the locally stored copy of the session and does not call the server.
 
 * _@param {string} name_ - name of the field
 * _@return {object}_ - the value that is stored under name
@@ -1232,7 +1232,7 @@ Clears the whole Batch Session data and sets it to an empty object `{}`.
 
 ### `jatos.batchSession.find`
 
-Gets a field in the Batch Session data. Takes a JSON Pointer and returns the matching value. Gets the object from the locally stored copy of the session and does not call the server. Contrary to `jatos.batchSession.get` it allows to get values from all levels of the Batch Session's object tree.
+Gets a field in the Batch Session data. Takes a JSON Pointer and returns the matching value, or `undefined` if the pointer does not correspond to an existing field. Gets the object from the locally stored copy of the session and does not call the server. Contrary to `jatos.batchSession.get` it allows to get values from all levels of the Batch Session's object tree.
 
 * _@param {string} path_ - JSON pointer path
 * _@return {object}_ - the value that is stored in path
@@ -1246,6 +1246,7 @@ Gets a field in the Batch Session data. Takes a JSON Pointer and returns the mat
    ```javascript
    jatos.batchSession.find("/a/a1"); // returns "foo"
    jatos.batchSession.find("/b"); // returns 999
+   jatos.batchSession.find("/c/d"); // returns undefined
    ```
 
 
@@ -1283,7 +1284,7 @@ JSON Patch test operation: Tests that the specified value is set in the document
    jatos.batchSession.test("/b/b1", "flowers"); // returns true
    ```
 
-1. If you want to know the existence of a path in the Batch Session you can test against `undefined`:
+1. If you want to know the existence of a path in the Batch Session you can test against `undefined`. The function `jatos.batchSession.defined` provides a shortcut for this use case.
 
    ```javascript
    if (!jatos.batchSession.test("/c", undefined)) {
@@ -1296,7 +1297,7 @@ JSON Patch test operation: Tests that the specified value is set in the document
 
 ### `jatos.batchSession.add`
 
-JSON Patch add operation: Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The `-` character can be used instead of an index to insert at the end of an array (see [jsonpatch.com](http://jsonpatch.com/)). If the path already exists in the Batch Session the value will be overwritten.
+JSON Patch add operation: Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The `-` character can be used instead of an index to insert at the end of an array (see [jsonpatch.com](http://jsonpatch.com/)). If the path already exists in the Batch Session the value will be overwritten. The patch will fail if a key other than the innermost one does not already exist.
 
 * _@param {string} path_ - JSON pointer path
 * _@param {object} value_ - value to be stored
@@ -1343,6 +1344,7 @@ JSON Patch add operation: Adds a value to an object or inserts it into an array.
    ```
 
    Afterwards the Batch Session contains `{"obj": {"foo": "bar"}}`.
+   Note that `jatos.batchSession.add("/obj/foo", "bar")` will fail if `"/obj"` does not already point to an object.
 
 1. Add an array:
 
@@ -1793,7 +1795,7 @@ Accessing the Group Session is done via [JSON Patches (RFC 6902)](https://tools.
 
 ### `jatos.groupSession.get`
 
-Convenience function: like `jatos.groupSession.find` but works with a key instead of a JSON Pointer (without the slash in front of the key name). Therefore it works only on the first level of the session's object tree. It takes a name of an field within the Group Session and returns the matching value.  For all other levels of the object tree use jatos.groupSession.find. Gets the object from the locally stored copy of the session and does not call the server.
+Convenience function: like `jatos.groupSession.find` but works with a key instead of a JSON Pointer (without the slash in front of the key name). Therefore it works only on the first level of the session's object tree. It takes a name of an field within the Group Session and returns the matching value, or `undefined` if the key does not exist. For all other levels of the object tree use jatos.groupSession.find. Gets the object from the locally stored copy of the session and does not call the server.
 
 * _@param {string} name_ - name of the field
 * _@return {object}_ - the value that is stored under name
@@ -1936,7 +1938,7 @@ Clears the whole Group Session data and sets it to an empty object `{}`.
 
 ### `jatos.groupSession.find`
 
-Gets a field in the Group Session data. Takes a JSON Pointer and returns the matching value. Gets the object from the locally stored copy of the session and does not call the server. Contrary to `jatos.groupSession.get` it allows to get values from all levels of the Group Session's object tree.
+Gets a field in the Group Session data. Takes a JSON Pointer and returns the matching value, or `undefined` if the pointer does not correspond to an existing field. Gets the object from the locally stored copy of the session and does not call the server. Contrary to `jatos.groupSession.get` it allows to get values from all levels of the Group Session's object tree.
 
 * _@param {string} path_ - JSON pointer path
 * _@return {object}_ - the value that is stored in path
@@ -1948,6 +1950,7 @@ Given the Group Session is `{"a": {"a1": "foo", "a2": "bar"}, "b": 999}`
 ```javascript
 jatos.groupSession.find("/a/a1"); // returns "foo"
 jatos.groupSession.find("/b"); // returns 999
+jatos.groupSession.find("/c/d"); // returns undefined
 ```
 
 the first line returns "foo" and the second 999.
@@ -1990,7 +1993,7 @@ the first line returns true, second false and third true.
 
 ### `jatos.groupSession.add`
 
-JSON Patch add operation: Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The `-` character can be used instead of an index to insert at the end of an array (see [jsonpatch.com](http://jsonpatch.com/)). If the path already exists in the Group Session the value will be overwritten.
+JSON Patch add operation: Adds a value to an object or inserts it into an array. In the case of an array, the value is inserted before the given index. The `-` character can be used instead of an index to insert at the end of an array (see [jsonpatch.com](http://jsonpatch.com/)). If the path already exists in the Group Session the value will be overwritten. The patch will fail if a key other than the innermost one does not already exist.
 
 * _@param {string} path_ - JSON pointer path
 * _@param {object} value_ - value to be stored


### PR DESCRIPTION
Add documentation for what can happen when various functions are supplied with invalid arguments or when fields are left empty. I have only documented the cases that I personally found non-obvious.

This depends on the changes in https://github.com/JATOS/JATOS/pull/277 being released since it documents the new behavior for `batchJsonInput`.